### PR TITLE
Listar Materias

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0",
         "react-paginate": "^8.3.0",
         "react-router-dom": "^7.8.2"
       },
@@ -8579,6 +8580,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "react-paginate": "^8.3.0",
     "react-router-dom": "^7.8.2"
   },

--- a/frontend/src/features/courses/components/CourseCard.jsx
+++ b/frontend/src/features/courses/components/CourseCard.jsx
@@ -1,19 +1,30 @@
+import { HiArrowRight } from "react-icons/hi";
+
 export default function CourseCard({ course }) {
   return (
-    <div className="h-auto bg-white rounded-lg shadow p-4 my-4 w-full flex flex-col justify-between cursor-pointer hover:shadow-lg transition-shadow">
-      <h2 className="text-black font-semibold text-lg">{course.name}</h2>
+    <div className="w-full bg-white rounded-lg shadow p-4 my-4 flex items-center justify-between gap-2">
+      <div className="items-start flex flex-col">
+        <h2 className="text-black font-semibold text-lg">{course.name}</h2>
 
-      {course.code && (
-        <p className="text-gray-700 text-sm">
-          <strong>Código:</strong> {course.code}
-        </p>
-      )}
+        {course.code && (
+          <p className="text-gray-700 text-sm">
+            <strong>Código:</strong> {course.code}
+          </p>
+        )}
 
-      {course.institute && (
-        <p className="text-gray-600 text-sm">
-          <strong>Instituto:</strong> {course.institute}
-        </p>
-      )}
+        {course.institute && (
+          <p className="text-gray-600 text-sm">
+            <strong>Instituto:</strong> {course.institute}
+          </p>
+        )}
+      </div>
+
+      <button
+        type="button"
+        className="inline-flex items-center text-white hover:text-white border border-gray-800 hover:bg-gray-900 focus:outline-none font-medium rounded-lg text-sm px-2 py-2 text-center me-2 mb-2 dark:border-gray-600 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600 cursor-pointer"
+      >
+        <HiArrowRight className="w-5 h-5" />
+      </button>
     </div>
   );
 }

--- a/frontend/src/features/courses/components/CourseList.jsx
+++ b/frontend/src/features/courses/components/CourseList.jsx
@@ -5,5 +5,11 @@ export default function CourseList({ courses, loading, error }) {
   if (error) return <div>Error al cargar las materias. </div>;
   if (courses.length === 0) return <div>No hay materias disponibles. </div>;
 
-  return courses.map((course) => <CourseCard key={course.id} course={course} />);
+  return(
+    <div className="flex flex-col">
+      {courses.map((course) => (
+        <CourseCard key={course.id} course={course} />
+      ))}
+    </div>
+    );
 }


### PR DESCRIPTION
### Cambios

- Cards de materias del mismo tamaño
- Botón para en proximo PR agregar funcionalidad Mostrar Materia
- Se instaló `react-icons` (ya disponible en el `package.json`, solo tienen que correr `npm install` para agregarla a su repo)
- Arranca a ser responsive la pagina

### Tests

- No se han agregado tests, en caso de que falte testear algo lo delego a @CamilaAM quien debe aprobar el PR una vez que se asegure que no falten Tests 

<img width="1437" height="753" alt="image" src="https://github.com/user-attachments/assets/6536bd4e-3006-48ea-ab4b-fc4d910ec9db" />
