### PR TITLE
Mostrar Materia no requiere autenticación del User

### DIFF
--- a/frontend/src/app/routes/index.jsx
+++ b/frontend/src/app/routes/index.jsx
@@ -17,13 +17,13 @@ export function AppRoutes() {
       </Route>
 
       <Route element={<PrivateRoute />}>
-        <Route path="/materias/:courseId" element={<CourseDetailPage />} />
         <Route path="/perfil" element={<ProfilePage />} />
       </Route>
 
       <Route path="/" element={<Navigate to="/materias" replace />} />
       <Route path="/materias" element={<CoursePage />} />
       <Route path="/tutores" element={<TutorPage />} />
+      <Route path="/materias/:courseId" element={<CourseDetailPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
En la ultima reunión con el cliente, se decidió remover la necesidad de estar autenticado para poder visualizar una materia. 

Este cambio debe tenerse en cuenta para el `Crear Tutoria`, ya que deben agregar las rutas de los botones que aparecen en el` Mostrar Materia` como `Private Routes`.
@KevinMacTec @Matiasdiazfont 