### PR TITLE
Remover fecha de vencimiento de un tema en la vista

### DIFF
--- a/frontend/src/features/subjects/components/SubjectCard.jsx
+++ b/frontend/src/features/subjects/components/SubjectCard.jsx
@@ -3,11 +3,6 @@ export default function SubjectCard({ subject, showCheckbox = false, onCheckboxC
     <div className="flex items-center justify-between p-2 pl-4 border rounded-md bg-gray-50 text-gray-800 text-sm hover:bg-gray-100 h-15">
       <div className="flex flex-col text-left">
         <span className="font-medium">{subject.name}</span>
-        {subject.due_date && (
-          <span className="text-gray-500 text-xs">
-            Vencimiento: {new Date(subject.due_date).toLocaleDateString("es-ES")}
-          </span>
-        )}
       </div>
       {showCheckbox && (
         <input

--- a/frontend/src/features/subjects/tests/SubjectPage.test.jsx
+++ b/frontend/src/features/subjects/tests/SubjectPage.test.jsx
@@ -76,30 +76,6 @@ describe("SubjectPage", () => {
     expect(await screen.findByText("Tema II")).toBeInTheDocument();
   });
 
-  it("muestra la fecha de vencimiento si existe", async () => {
-    const subjectsWithDueDate = [
-      { id: 1, name: "Tema I", due_date: "2025-09-30T12:00:00Z" }
-    ];
-
-  
-    subjectService.getSubjects.mockResolvedValue({
-      subjects: subjectsWithDueDate,
-      pagination: { last: 1 },
-    });
-  
-    render(
-      <MemoryRouter>
-        <SubjectPage courseId={123} />
-      </MemoryRouter>
-    );
-  
-    // Verifica que el tema se muestre
-    expect(await screen.findByText("Tema I")).toBeInTheDocument();
-  
-    // Verifica que la fecha de vencimiento se muestre formateada
-    expect(screen.getByText(/Vencimiento:\s*30\/9\/2025/)).toBeInTheDocument();
-  });
-
   it("muestra checkboxes si showCheckbox es true", async () => {
     subjectService.getSubjects.mockResolvedValue({
       subjects: mockSubjects,


### PR DESCRIPTION
Esta fecha es para uso interno de la página, no debería mostrarse al usuario ya que, siguiendo nuestra especificación, la fecha de vencimiento de un tema se renueva en caso de que pertenezca a una tutoria. 

No es algo que aporte información al usuario 🙂 