### PR TITLE
arreglo en query de filtro de tutores

### DIFF
--- a/backend/app/controllers/api/v1/users/users_controller.rb
+++ b/backend/app/controllers/api/v1/users/users_controller.rb
@@ -9,7 +9,13 @@ module Api
         def index
           users = User.all
 
-          users = users.where("unaccent(name) ILIKE unaccent(?)", "%#{params[:search]}%") if params[:search].present?
+          if params[:search].present?
+            search = params[:search].strip.squeeze(" ")
+            users = users.where(
+              "unaccent(name || ' ' || last_name) ILIKE unaccent(?)",
+              "%#{search}%"
+            )
+          end
 
           # users = users.where(role: params[:role]) if params[:role].present?
 


### PR DESCRIPTION
Se resuelven estos casos que no se cumplían:

Sin filtro se visualiza el usuario de nombre Ana Pérez

Al buscar ‘Pérez’ → no aparece el usuario ( falla )
Al buscar ‘Ana ' (con un espacio al final) → no aparece el usuario ( falla )
Al buscar 'Ana Pérez’ → no aparece el usuario ( falla )